### PR TITLE
Fix metric name typo

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -66,7 +66,7 @@ def main():
     # 订单级计数
     metrics = {
         "订单数": pair_df.groupby(sku_col)["order_id"].nunique(),
-        "出库订单数数量": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
+        "出库订单数": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
         "签收订单数": pair_df[pair_df["_status"].isin(["delivered","completed"])]\
                      .groupby(sku_col)["order_id"].nunique(),
         "取消订单数": pair_df[pair_df["_status"]=="cancelled"].groupby(sku_col)["order_id"].nunique(),

--- a/analysis_multi.py
+++ b/analysis_multi.py
@@ -168,7 +168,7 @@ def process_financial_data(order_files: List[Union[str, Path]],
     # 订单级计数
     metrics = {
         "订单数": pair_df.groupby(sku_col)["order_id"].nunique(),
-        "出库订单数数量": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
+        "出库订单数": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
         "签收订单数": pair_df[pair_df["_status"].isin(["delivered","completed"])]\
                      .groupby(sku_col)["order_id"].nunique(),
         "取消订单数": pair_df[pair_df["_status"]=="cancelled"].groupby(sku_col)["order_id"].nunique(),


### PR DESCRIPTION
## Summary
- minor fix in metrics: rename incorrect key `出库订单数数量` to `出库订单数`

## Testing
- `python -m py_compile app.py analysis_multi.py analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4baed9a08323b047fbc596eed477