### PR TITLE
Add module selection front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 ```
 ├── app.py              # Flask Web服务器
-├── analysis_multi.py   # 多文件分析引擎  
+├── analysis_multi.py   # 多文件分析引擎（印尼财务分析）
+├── analysis_malaysia.py # 占位的马来跨境财务分析模块
 ├── analysis.py         # 原始单文件分析脚本
 ├── index.html          # Web前端页面
 ├── requirements.txt    # 项目依赖

--- a/analysis.py
+++ b/analysis.py
@@ -66,7 +66,7 @@ def main():
     # 订单级计数
     metrics = {
         "订单数": pair_df.groupby(sku_col)["order_id"].nunique(),
-        "出库订单数数量": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
+        "出库订单数": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
         "签收订单数": pair_df[pair_df["_status"].isin(["delivered","completed"])]\
                      .groupby(sku_col)["order_id"].nunique(),
         "取消订单数": pair_df[pair_df["_status"]=="cancelled"].groupby(sku_col)["order_id"].nunique(),

--- a/analysis_malaysia.py
+++ b/analysis_malaysia.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Placeholder for Malaysian cross-border financial analysis module."""
+
+from pathlib import Path
+from typing import List, Union
+
+
+def process_financial_data(order_files: List[Union[str, Path]],
+                           settlement_files: List[Union[str, Path]],
+                           consumption_file: Union[str, Path],
+                           output_dir: Union[str, Path]):
+    """Placeholder implementation."""
+    raise NotImplementedError(
+        "马来跨境财务分析模块尚未实现")
+

--- a/analysis_multi.py
+++ b/analysis_multi.py
@@ -168,7 +168,7 @@ def process_financial_data(order_files: List[Union[str, Path]],
     # 订单级计数
     metrics = {
         "订单数": pair_df.groupby(sku_col)["order_id"].nunique(),
-        "出库订单数数量": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
+        "出库订单数": pair_df[pair_df["_shipped"]=="yes"].groupby(sku_col)["order_id"].nunique(),
         "签收订单数": pair_df[pair_df["_status"].isin(["delivered","completed"])]\
                      .groupby(sku_col)["order_id"].nunique(),
         "取消订单数": pair_df[pair_df["_status"]=="cancelled"].groupby(sku_col)["order_id"].nunique(),

--- a/app.py
+++ b/app.py
@@ -13,7 +13,13 @@ from werkzeug.utils import secure_filename
 import pandas as pd
 
 # 导入修改后的分析模块
-from analysis_multi import process_financial_data
+from analysis_multi import process_financial_data as process_indonesia
+from analysis_malaysia import process_financial_data as process_malaysia
+
+ANALYSIS_FUNCTIONS = {
+    'indonesia': process_indonesia,
+    'malaysia': process_malaysia,
+}
 
 app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024  # 100MB
@@ -59,6 +65,8 @@ def process_files():
             if file.filename == '' or not allowed_file(file.filename):
                 return jsonify({'error': f'文件 {file.filename} 格式不正确，请上传Excel文件'}), 400
 
+        module = request.form.get('module', 'indonesia')
+
         # 创建临时目录
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -86,7 +94,8 @@ def process_files():
 
             # 执行数据分析
             try:
-                output_path = process_financial_data(
+                analysis_func = ANALYSIS_FUNCTIONS.get(module, process_indonesia)
+                output_path = analysis_func(
                     order_files=order_paths,
                     settlement_files=settlement_paths,
                     consumption_file=consumption_path,

--- a/index.html
+++ b/index.html
@@ -134,6 +134,18 @@
             margin-top: 40px;
         }
 
+        .module-select {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+
+        .module-select select {
+            padding: 8px 12px;
+            border-radius: 8px;
+            border: 1px solid #ccc;
+            font-size: 1rem;
+        }
+
         .process-btn {
             background: linear-gradient(45deg, #2ed573, #1e90ff);
             color: white;
@@ -261,6 +273,13 @@
         </div>
 
         <div class="process-section">
+            <div class="module-select">
+                <label for="module-select">选择分析模块：</label>
+                <select id="module-select">
+                    <option value="indonesia">印尼财务分析</option>
+                    <option value="malaysia">马来跨境财务分析</option>
+                </select>
+            </div>
             <button class="process-btn" id="process-btn" onclick="processFiles()" disabled>
                 🚀 开始分析
             </button>
@@ -279,6 +298,11 @@
             settlements: [],
             consumption: null
         };
+
+        let selectedModule = 'indonesia';
+        document.getElementById('module-select').addEventListener('change', e => {
+            selectedModule = e.target.value;
+        });
 
         // 初始化拖拽功能
         document.querySelectorAll('.upload-box').forEach(box => {
@@ -419,6 +443,9 @@
                 
                 // 添加消耗文件
                 formData.append('consumption', fileStorage.consumption);
+
+                // 选择的分析模块
+                formData.append('module', selectedModule);
 
                 // 模拟进度更新
                 let progress_value = 0;

--- a/start.sh
+++ b/start.sh
@@ -20,7 +20,7 @@ echo "📦 检查并安装依赖..."
 pip install -r requirements.txt
 
 # 检查必要文件
-required_files=("app.py" "analysis_multi.py" "index.html")
+required_files=("app.py" "analysis_multi.py" "analysis_malaysia.py" "index.html")
 for file in "${required_files[@]}"; do
     if [ ! -f "$file" ]; then
         echo "❌ 缺少必要文件: $file"


### PR DESCRIPTION
## Summary
- add dropdown to choose analysis module
- send selected module to backend
- route backend to Indonesia or Malaysia module
- include placeholder `analysis_malaysia.py`

## Testing
- `python -m py_compile app.py analysis.py analysis_multi.py analysis_malaysia.py`
- `bash start.sh` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f4baed9a08323b047fbc596eed477